### PR TITLE
Updating terraform-aws-label version

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ logging_configuration = {
 | <a name="module_central_inspection_with_egress_routing"></a> [central\_inspection\_with\_egress\_routing](#module\_central\_inspection\_with\_egress\_routing) | ./modules/central_inspection_with_egress_routing | n/a |
 | <a name="module_intra_vpc_routing"></a> [intra\_vpc\_routing](#module\_intra\_vpc\_routing) | ./modules/intra_vpc_routing | n/a |
 | <a name="module_logging"></a> [logging](#module\_logging) | ./modules/logging | n/a |
-| <a name="module_tags"></a> [tags](#module\_tags) | aws-ia/label/aws | 0.0.5 |
+| <a name="module_tags"></a> [tags](#module\_tags) | aws-ia/label/aws | 0.0.6 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@
 # awscc tags = module.tags.tags
 module "tags" {
   source  = "aws-ia/label/aws"
-  version = "0.0.5"
+  version = "0.0.6"
 
   tags = var.tags
 }


### PR DESCRIPTION
# Updating [terraform-aws-label](https://github.com/aws-ia/terraform-aws-label) version
Updating the version to 0.0.6 since AWSCC is GA and `tags` module has been updated with new version constraint for `awscc` provider `">= 1.0"`